### PR TITLE
Fix acm cert resource not using ID from state on updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Terraform Provider",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      // this assumes your workspace is the root of the repo
+      "program": "${workspaceFolder}",
+      "env": {},
+      "args": ["-debug"]
+    },
+    {
+      "name": "Run tests",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      // this assumes your workspace is the root of the repo
+      "program": "${workspaceFolder}",
+      "env": {},
+      "args": ["TF_ACC=1 go test -v ./..."]
+    },
+    {
+      "name": "Run sample file",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      // this assumes your workspace is the root of the repo
+      "program": "${workspaceFolder}/cmd/main.go",
+      "env": {},
+      "args": []
+    }
+  ]
+}

--- a/internal/provider/aws_acm_certificate.go
+++ b/internal/provider/aws_acm_certificate.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -50,6 +52,9 @@ func (r *AWSACMCertificateResource) Schema(ctx context.Context, req resource.Sch
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The certificate ID",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"arn": schema.StringAttribute{
 				MarkdownDescription: "The Amazon Resource Name (ARN) of the certificate",

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "common-fate/deploymeta",
+		Address: "commonfate.com/commonfate/deploymeta",
 		Debug:   debug,
 	}
 

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		// TODO: Update this string with the published name of your provider.
 		// Also update the tfplugindocs generate command to either remove the
 		// -provider-name flag or set its value to the updated provider name.
-		Address: "registry.terraform.io/hashicorp/scaffolding",
+		Address: "common-fate/deploymeta",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
Previously the ID would not be sent through on updates causing a 404 error 